### PR TITLE
Fixed Undefined array key "page" warning and added fallback for "RATING:"

### DIFF
--- a/php/components/pagination-category-subpages.php
+++ b/php/components/pagination-category-subpages.php
@@ -15,11 +15,10 @@ $wp_url .= "&per_page=24";
 $headers = get_headers($wp_url, true);
 $page_count = $headers["X-WP-TotalPages"];
 
-// Get current page
-$page = intval($_GET['page']); // FIXME: Fix the Undefined array key "page" warning for this
-
-// Default page
-if ($page == 0) {
+// Get current page number of current URL
+if (isset($_GET['page'])) { // If there is a page parameter in the URL
+    $page = intval($_GET['page']); 
+} else { // Otherwise, assume that it's the first page
     $page = 1;
 }
 

--- a/php/components/pagination-search-results.php
+++ b/php/components/pagination-search-results.php
@@ -19,7 +19,11 @@
 <?php
 
 // The page to display (Usually is received in a url parameter)
-$page = intval($_GET['page']); // FIXME: Fix the Undefined array key "page" warning for this
+if (isset($_GET['page'])) { // If there is a page parameter in the URL
+    $page = intval($_GET['page']); 
+} else { // Otherwise, assume that it's the first page
+    $page = 1;
+}
 
 // The number of records to display per page
 $page_size = 24;

--- a/php/functions/functions-global.php
+++ b/php/functions/functions-global.php
@@ -54,6 +54,7 @@ function get_rating($content)
 
     // Remove the 'Rating: ' prefix
     $rating = str_replace("Rating: ", "", $rating);
+    $rating = str_replace("RATING: ", "", $rating); // Fallback if author used all caps
     
     return $rating;
 }

--- a/php/search-processing.php
+++ b/php/search-processing.php
@@ -10,7 +10,7 @@
 /**
  * SEARCH PROCESSING
  */
-if (intval($_GET['page']) == 0) { // FIXME: Fix the Undefined array key "page" warning for this
+if (!isset($_GET['page'])) { // If first time loading the search results
     // Get the search query entered by the user in the previous page
     $_SESSION["search_query"] = $_POST["search-query"];
 


### PR DESCRIPTION
- Fixed the warning `Undefined array key "page"` for the category subpages and search results subpage by checking first if `isset($_GET['page'])`. Solution described [here](https://stackoverflow.com/questions/65603660/beginner-php-warning-undefined-array-key).
- Added a line of code that removes "RATING:" as well, in case author used that instead of title case "Rating:"