### PR TITLE
Normalize `X-WP-TotalPages` header to lowercase for paginations in categories and search results

### DIFF
--- a/php/components/pagination-category-subpages.php
+++ b/php/components/pagination-category-subpages.php
@@ -13,7 +13,8 @@ $wp_url .= "&per_page=24";
 
 // Get number of pages
 $headers = get_headers($wp_url, true);
-$page_count = $headers["X-WP-TotalPages"];
+$headers = array_change_key_case($headers, CASE_LOWER); // Normalize header keys to lowercase
+$page_count = $headers["x-wp-totalpages"]; // Access the key in lowercase
 
 // Get current page number of current URL
 if (isset($_GET['page'])) { // If there is a page parameter in the URL

--- a/php/search-processing.php
+++ b/php/search-processing.php
@@ -23,7 +23,8 @@ if (!isset($_GET['page'])) { // If first time loading the search results
     
     // Get the total number of pages of the list of articles
     $headers = get_headers($wp_url, true);
-    $page_count = $headers["X-WP-TotalPages"]; 
+    $headers = array_change_key_case($headers, CASE_LOWER); // Normalize header keys to lowercase
+    $page_count = $headers["x-wp-totalpages"]; // Access the key in lowercase
     
     // Create array that will store all search results
     $_SESSION["all_articles"] = array();


### PR DESCRIPTION
This pull request standardizes the handling of HTTP headers by normalizing their keys to lowercase before accessing them. 

This change fixes Issue #16, where the warning `Undefined array key "X-WP-TotalPages"` appears on the web pages.

### Standardizing HTTP Header Handling:
* In `php/components/pagination-category-subpages.php`, the `get_headers` result is processed with `array_change_key_case` to normalize header keys to lowercase, and the `X-WP-TotalPages` header is accessed as `x-wp-totalpages`.
* In `php/search-processing.php`, the same normalization approach is applied to ensure consistent access to the `X-WP-TotalPages` header as `x-wp-totalpages`.

(This description was generated by AI and edited.)